### PR TITLE
feat(FieldErrorMessageTrait): use method instead of property for post…

### DIFF
--- a/src/Model/FieldErrorMessageTrait.php
+++ b/src/Model/FieldErrorMessageTrait.php
@@ -38,13 +38,11 @@ trait FieldErrorMessageTrait
     protected bool $checked;
 
     /**
-     * Determines if the model is being
-     * created or updated.
-     *
-     * Validation is usually not desired
-     * when viewing the model.
+     * Validation is usually only desired
+     * when the user attempts to
+     * create or edit a model.
      */
-    protected bool $isPosted = false;
+    protected bool $shouldValidate = false;
 
     /**
      * Provides an interface for
@@ -68,11 +66,19 @@ trait FieldErrorMessageTrait
      */
     public function hasError(string $fieldName): bool
     {
-        if ($this->isPosted === false) {
+        if ($this->shouldValidate === false) {
             return false;
         }
         $this->setErrorMsgsOnce();
         return isset($this->errorMessages[$fieldName]);
+    }
+
+    /**
+     * Changes the posted state of the model.
+     */
+    public function isPosted(): void
+    {
+        $this->shouldValidate = true;
     }
 
     private function setErrorMsgsOnce(): void

--- a/tests/__data-providers__/FormFieldErrorMessageDataProvider.php
+++ b/tests/__data-providers__/FormFieldErrorMessageDataProvider.php
@@ -20,7 +20,7 @@ final class FormFieldErrorMessageDataProvider
             "Value is greater than the maximum",
             new class () extends AbstractModel
             {
-                protected bool $isPosted = true;
+                protected bool $shouldValidate = true;
 
                 #[Max(50)]
                 public int $prop = 51;
@@ -30,7 +30,7 @@ final class FormFieldErrorMessageDataProvider
             "Value is greater than the maximum",
             new class () extends AbstractModel
             {
-                protected bool $isPosted = true;
+                protected bool $shouldValidate = true;
 
                 #[Max(50)]
                 public int $prop = 51;
@@ -40,7 +40,7 @@ final class FormFieldErrorMessageDataProvider
             "Maximum length validation failed",
             new class () extends AbstractModel
             {
-                protected bool $isPosted = true;
+                protected bool $shouldValidate = true;
                 #[MaxLength(10)]
                 public string $prop = "9123456780a";
             },
@@ -49,7 +49,7 @@ final class FormFieldErrorMessageDataProvider
             "Value is less than the minimum",
             new class () extends AbstractModel
             {
-                protected bool $isPosted = true;
+                protected bool $shouldValidate = true;
                 #[Min(5)]
                 public int $prop = 4;
             }
@@ -58,7 +58,7 @@ final class FormFieldErrorMessageDataProvider
             "Minimum length validation failed",
             new class () extends AbstractModel
             {
-                protected bool $isPosted = true;
+                protected bool $shouldValidate = true;
                 #[MinLength(10)]
                 public string $prop = "123456780";
             },
@@ -67,7 +67,7 @@ final class FormFieldErrorMessageDataProvider
             "Pattern validation failed",
             new class () extends AbstractModel
             {
-                protected bool $isPosted = true;
+                protected bool $shouldValidate = true;
                 #[Pattern("/^[[:alnum:]]+$/")]
                 public string $prop = "abcd1234$$;%";
             },
@@ -76,7 +76,7 @@ final class FormFieldErrorMessageDataProvider
             "Required value",
             new class () extends AbstractModel
             {
-                protected bool $isPosted = true;
+                protected bool $shouldValidate = true;
                 #[Required]
                 public string $prop;
             },
@@ -88,7 +88,7 @@ final class FormFieldErrorMessageDataProvider
         yield [
             new class () extends AbstractModel
             {
-                protected bool $isPosted = false;
+                protected bool $shouldValidate = false;
 
                 #[Max(50)]
                 public int $prop = 51;
@@ -97,7 +97,7 @@ final class FormFieldErrorMessageDataProvider
         yield [
             new class () extends AbstractModel
             {
-                protected bool $isPosted = false;
+                protected bool $shouldValidate = false;
 
                 #[Max(50)]
                 public int $prop = 51;
@@ -106,7 +106,7 @@ final class FormFieldErrorMessageDataProvider
         yield [
             new class () extends AbstractModel
             {
-                protected bool $isPosted = false;
+                protected bool $shouldValidate = false;
                 #[MaxLength(10)]
                 public string $prop = "9123456780a";
             },
@@ -114,7 +114,7 @@ final class FormFieldErrorMessageDataProvider
         yield [
             new class () extends AbstractModel
             {
-                protected bool $isPosted = false;
+                protected bool $shouldValidate = false;
                 #[Min(5)]
                 public int $prop = 4;
             }
@@ -122,7 +122,7 @@ final class FormFieldErrorMessageDataProvider
         yield [
             new class () extends AbstractModel
             {
-                protected bool $isPosted = false;
+                protected bool $shouldValidate = false;
                 #[MinLength(10)]
                 public string $prop = "123456780";
             },
@@ -130,7 +130,7 @@ final class FormFieldErrorMessageDataProvider
         yield [
             new class () extends AbstractModel
             {
-                protected bool $isPosted = false;
+                protected bool $shouldValidate = false;
                 #[Pattern("/^[[:alnum:]]+$/")]
                 public string $prop = "abcd1234$$;%";
             },
@@ -138,7 +138,7 @@ final class FormFieldErrorMessageDataProvider
         yield [
             new class () extends AbstractModel
             {
-                protected bool $isPosted = false;
+                protected bool $shouldValidate = false;
                 #[Required]
                 public string $prop;
             },
@@ -151,7 +151,7 @@ final class FormFieldErrorMessageDataProvider
             "",
             new class () extends AbstractModel
             {
-                protected bool $isPosted = true;
+                protected bool $shouldValidate = true;
                 #[Required]
                 public string $prop = "REQUIRED PROP IS SET";
             }

--- a/tests/unit/Model/FieldErrorMessageTraitTest.php
+++ b/tests/unit/Model/FieldErrorMessageTraitTest.php
@@ -65,10 +65,23 @@ final class FieldErrorMessageTraitTest extends TestCase
         $this->assertFalse($model->hasError($fieldName));
     }
 
+    #[TestDox("Shall have errors when the model is posted and the property is invalid")]
+    public function test5a()
+    {
+        $model = new class () extends AbstractModel
+        {
+            #[Required]
+            public string $prop;
+        };
+        $model->isPosted();
+        $this->assertTrue($model->hasError("prop"));
+    }
+
     #[TestDox("Shall not have errors when the model is not posted/submitted")]
     #[DataProviderExternal(FormFieldErrorMessageDataProvider::class, "invalidPropertyNotPostedTestCases")]
-    public function test5(object $model)
+    public function test5b(object $model)
     {
+
         $fieldName = "prop";
         $this->assertFalse($model->hasError($fieldName));
     }

--- a/tests/unit/Validation/MaxLengthTest.php
+++ b/tests/unit/Validation/MaxLengthTest.php
@@ -36,7 +36,7 @@ final class MaxLengthTest extends TestCase
 
             public function __construct(string $prop)
             {
-                $this->isPosted = true;
+                $this->shouldValidate = true;
                 $this->property = $prop;
             }
         };
@@ -59,7 +59,7 @@ final class MaxLengthTest extends TestCase
 
             public function __construct(string $prop)
             {
-                $this->isPosted = true;
+                $this->shouldValidate = true;
                 $this->property = $prop;
             }
         };
@@ -82,7 +82,7 @@ final class MaxLengthTest extends TestCase
 
             public function __construct(int|float $prop)
             {
-                $this->isPosted = true;
+                $this->shouldValidate = true;
                 $this->property = $prop;
             }
         };
@@ -105,7 +105,7 @@ final class MaxLengthTest extends TestCase
 
             public function __construct(int|float $prop)
             {
-                $this->isPosted = true;
+                $this->shouldValidate = true;
                 $this->property = $prop;
             }
         };
@@ -127,7 +127,7 @@ final class MaxLengthTest extends TestCase
 
             public function __construct(mixed $prop)
             {
-                $this->isPosted = true;
+                $this->shouldValidate = true;
                 $this->property = $prop;
             }
         };

--- a/tests/unit/Validation/MaxTest.php
+++ b/tests/unit/Validation/MaxTest.php
@@ -35,7 +35,7 @@ final class MaxTest extends TestCase
 
             public function __construct(int|float $prop)
             {
-                $this->isPosted = true;
+                $this->shouldValidate = true;
                 $this->property = $prop;
             }
         };
@@ -58,7 +58,7 @@ final class MaxTest extends TestCase
 
             public function __construct(int|float $prop)
             {
-                $this->isPosted = true;
+                $this->shouldValidate = true;
                 $this->property = $prop;
             }
         };
@@ -80,7 +80,7 @@ final class MaxTest extends TestCase
 
             public function __construct(mixed $prop)
             {
-                $this->isPosted = true;
+                $this->shouldValidate = true;
                 $this->property = $prop;
             }
         };

--- a/tests/unit/Validation/MinLengthTest.php
+++ b/tests/unit/Validation/MinLengthTest.php
@@ -75,7 +75,7 @@ final class MinLengthTest extends TestCase
 
             public function __construct(int|float $prop)
             {
-                $this->isPosted = true;
+                $this->shouldValidate = true;
                 $this->property = $prop;
             }
         };
@@ -98,7 +98,7 @@ final class MinLengthTest extends TestCase
 
             public function __construct(int|float $prop)
             {
-                $this->isPosted = true;
+                $this->shouldValidate = true;
                 $this->property = $prop;
             }
         };
@@ -121,7 +121,7 @@ final class MinLengthTest extends TestCase
 
             public function __construct(mixed $prop)
             {
-                $this->isPosted = true;
+                $this->shouldValidate = true;
                 $this->property = $prop;
             }
         };

--- a/tests/unit/Validation/MinTest.php
+++ b/tests/unit/Validation/MinTest.php
@@ -35,7 +35,7 @@ class MinTest extends TestCase
 
             public function __construct(int|float $prop)
             {
-                $this->isPosted = true;
+                $this->shouldValidate = true;
                 $this->property = $prop;
             }
         };
@@ -58,7 +58,7 @@ class MinTest extends TestCase
 
             public function __construct(int|float $prop)
             {
-                $this->isPosted = true;
+                $this->shouldValidate = true;
                 $this->property = $prop;
             }
         };
@@ -80,7 +80,7 @@ class MinTest extends TestCase
 
             public function __construct(mixed $prop)
             {
-                $this->isPosted = true;
+                $this->shouldValidate = true;
                 $this->property = $prop;
             }
         };

--- a/tests/unit/Validation/PatternTest.php
+++ b/tests/unit/Validation/PatternTest.php
@@ -34,7 +34,7 @@ final class PatternTest extends TestCase
 
             public function __construct(mixed $prop)
             {
-                $this->isPosted = true;
+                $this->shouldValidate = true;
                 $this->property = $prop;
             }
         };
@@ -57,7 +57,7 @@ final class PatternTest extends TestCase
 
             public function __construct(mixed $prop)
             {
-                $this->isPosted = true;
+                $this->shouldValidate = true;
                 $this->property = $prop;
             }
         };
@@ -79,7 +79,7 @@ final class PatternTest extends TestCase
 
             public function __construct()
             {
-                $this->isPosted = true;
+                $this->shouldValidate = true;
             }
         };
 
@@ -101,7 +101,7 @@ final class PatternTest extends TestCase
 
             public function __construct(mixed $invalidVal)
             {
-                $this->isPosted = true;
+                $this->shouldValidate = true;
                 $this->property = $invalidVal;
             }
         };

--- a/tests/unit/Validation/RequiredTest.php
+++ b/tests/unit/Validation/RequiredTest.php
@@ -34,7 +34,7 @@ final class RequiredTest extends TestCase
 
             public function __construct(mixed $prop)
             {
-                $this->isPosted = true;
+                $this->shouldValidate = true;
                 $this->property = $prop;
             }
         };
@@ -56,7 +56,7 @@ final class RequiredTest extends TestCase
 
             public function __construct()
             {
-                $this->isPosted = true;
+                $this->shouldValidate = true;
             }
         };
 


### PR DESCRIPTION
…ed state

The posted state of the model should remain encapsulated.  The user will have to call the `isPosted` method when validation is required.  Request aware logic is best managed outside of the model.

Closes #92