### PR TITLE
refactor: do not send response in middleware queue

### DIFF
--- a/src/WebServer/AbortProcessingRequest.php
+++ b/src/WebServer/AbortProcessingRequest.php
@@ -4,9 +4,22 @@ declare(strict_types=1);
 
 namespace Phpolar\Phpolar\WebServer;
 
+use Psr\Http\Message\ResponseInterface;
+
 /**
  * Use to notify the web server that the request shall not be processed
  */
 final class AbortProcessingRequest
 {
+    public function __construct(private ResponseInterface $response)
+    {
+    }
+
+    /**
+     * Retrieves the response.
+     */
+    public function getResponse(): ResponseInterface
+    {
+        return $this->response;
+    }
 }

--- a/src/WebServer/MiddlewareProcessingQueue.php
+++ b/src/WebServer/MiddlewareProcessingQueue.php
@@ -64,8 +64,7 @@ final class MiddlewareProcessingQueue
         );
         foreach ($preRoutingResponses as $preRoutingResponse) {
             if ($preRoutingResponse->getStatusCode() >= 400) {
-                ResponseExtension::extend($preRoutingResponse)->send();
-                return new AbortProcessingRequest();
+                return new AbortProcessingRequest($preRoutingResponse);
             }
         }
         return new ContinueProcessingRequest();

--- a/src/WebServer/WebServer.php
+++ b/src/WebServer/WebServer.php
@@ -78,6 +78,7 @@ final class WebServer
         $primaryHandler = $this->containerManager->getPrimaryRequestHandler($this->shouldUseRoutes, $this->routes);
         $result = $this->middlewareQueue->dequeuePreRoutingMiddleware($request);
         if ($result instanceof AbortProcessingRequest) {
+            ResponseExtension::extend($result->getResponse())->send();
             return;
         }
         $routingResponse = $primaryHandler->handle($request);


### PR DESCRIPTION
Sending the error response in the web server makes the intent a little more clear.

Closes #101