### PR TITLE
refactor: rename abstract route delegate to abstract content delegate

### DIFF
--- a/src/Routing/AbstractContentDelegate.php
+++ b/src/Routing/AbstractContentDelegate.php
@@ -11,15 +11,15 @@ use Psr\Container\ContainerInterface;
  *
  * This is expected to return the content of the
  * response body.
- *
- * This is **NOT** a PSR-15 request handler.
  */
-abstract class AbstractRouteDelegate
+abstract class AbstractContentDelegate
 {
     /**
-     * Execute the defined action associated with a given route.
+     * Returns the content of the response body.
+     *
+     * This may also execute any action associated with a given route.
      *
      * @return string The content of the response body.
      */
-    abstract public function handle(ContainerInterface $container): string;
+    abstract public function getResponseContent(ContainerInterface $container): string;
 }

--- a/src/Routing/DefaultRoutingHandler.php
+++ b/src/Routing/DefaultRoutingHandler.php
@@ -45,7 +45,7 @@ class DefaultRoutingHandler implements RequestHandlerInterface
         if ($handler instanceof RouteNotRegistered) {
             return (new ErrorHandler(ResponseCode::NOT_FOUND, "Not Found", $this->container))->handle($request);
         }
-        $responseContent = $handler->handle($this->container);
+        $responseContent = $handler->getResponseContent($this->container);
         $responseStream = $streamFactory->createStream($responseContent);
         $response = $responseFactory->createResponse();
         return $response->withBody($responseStream);

--- a/src/Routing/RouteRegistry.php
+++ b/src/Routing/RouteRegistry.php
@@ -11,19 +11,19 @@ namespace Phpolar\Phpolar\Routing;
 class RouteRegistry
 {
     /**
-     * @var array<string,AbstractRouteDelegate> Stores actions for `GET` requests.
+     * @var array<string,AbstractContentDelegate> Stores actions for `GET` requests.
      */
     private array $registryForGet = [];
 
     /**
-     * @var array<string,AbstractRouteDelegate> Stores actions for `POST` requests.
+     * @var array<string,AbstractContentDelegate> Stores actions for `POST` requests.
      */
     private array $registryForPost = [];
 
     /**
      * Associates a request handler to a `GET` request.
      */
-    public function addGet(string $route, AbstractRouteDelegate $handler): void
+    public function addGet(string $route, AbstractContentDelegate $handler): void
     {
         $this->registryForGet[$route] = $handler;
     }
@@ -31,7 +31,7 @@ class RouteRegistry
     /**
      * Associates a request handler to a `POST` request.
      */
-    public function addPost(string $route, AbstractRouteDelegate $handler): void
+    public function addPost(string $route, AbstractContentDelegate $handler): void
     {
         $this->registryForPost[$route] = $handler;
     }
@@ -39,7 +39,7 @@ class RouteRegistry
     /**
      * Retrieves the registered handler for a `GET` request.
      */
-    public function fromGet(string $route): AbstractRouteDelegate|RouteNotRegistered
+    public function fromGet(string $route): AbstractContentDelegate|RouteNotRegistered
     {
         return $this->registryForGet[$route] ?? new RouteNotRegistered();
     }
@@ -47,7 +47,7 @@ class RouteRegistry
     /**
      * Retrieves the registered handler for a `POST` request.
      */
-    public function fromPost(string $route): AbstractRouteDelegate|RouteNotRegistered
+    public function fromPost(string $route): AbstractContentDelegate|RouteNotRegistered
     {
         return $this->registryForPost[$route] ?? new RouteNotRegistered();
     }

--- a/tests/acceptance/RoutingTest.php
+++ b/tests/acceptance/RoutingTest.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Phpolar\Phpolar\Routing;
 
 use Exception;
-use Phan\Language\Element\ConstantInterface;
 use Phpolar\HttpCodes\ResponseCode;
 use Phpolar\Phpolar\Tests\Stubs\MemoryStreamStub;
 use Phpolar\Phpolar\Tests\Stubs\ResponseStub;
@@ -83,12 +82,12 @@ final class RoutingTest extends TestCase
         $givenRoute = "/";
         $expectedResponse = "<h1>Found!</h1>";
         $routeRegistry = new RouteRegistry();
-        $indexHandler = new class ($expectedResponse) extends AbstractRouteDelegate {
+        $indexHandler = new class ($expectedResponse) extends AbstractContentDelegate {
             public function __construct(private string $responseTemplate)
             {
             }
 
-            public function handle(ContainerInterface $container): string
+            public function getResponseContent(ContainerInterface $container): string
             {
                 return $this->responseTemplate;
             }

--- a/tests/unit/Routing/DefaultRoutingHandlerTest.php
+++ b/tests/unit/Routing/DefaultRoutingHandlerTest.php
@@ -84,8 +84,8 @@ final class DefaultRoutingHandlerTest extends TestCase
         /**
          * @var MockObject $registeredRouteHandler
          */
-        $registeredRouteHandler = $this->createMock(AbstractRouteDelegate::class);
-        $registeredRouteHandler->expects($this->once())->method("handle");
+        $registeredRouteHandler = $this->createMock(AbstractContentDelegate::class);
+        $registeredRouteHandler->expects($this->once())->method("getResponseContent");
         /**
          * @var Stub&RouteRegistry $routeRegistryStub
          */
@@ -110,8 +110,8 @@ final class DefaultRoutingHandlerTest extends TestCase
         /**
          * @var Stub $registeredRouteHandler
          */
-        $registeredRouteHandler = $this->createStub(AbstractRouteDelegate::class);
-        $registeredRouteHandler->method("handle")->willReturn($responseContent);
+        $registeredRouteHandler = $this->createStub(AbstractContentDelegate::class);
+        $registeredRouteHandler->method("getResponseContent")->willReturn($responseContent);
         /**
          * @var Stub&RouteRegistry $routeRegistryStub
          */

--- a/tests/unit/Routing/RouteRegistryTest.php
+++ b/tests/unit/Routing/RouteRegistryTest.php
@@ -20,14 +20,14 @@ final class RouteRegistryTest extends TestCase
     {
         $givenRoute = "/";
         /**
-         * @var MockObject&AbstractRouteDelegate $handlerSpy
+         * @var MockObject&AbstractContentDelegate $handlerSpy
          */
-        $handlerSpy = $this->getMockForAbstractClass(AbstractRouteDelegate::class);
-        $handlerSpy->expects($this->once())->method("handle")->willReturn("");
+        $handlerSpy = $this->getMockForAbstractClass(AbstractContentDelegate::class);
+        $handlerSpy->expects($this->once())->method("getResponseContent")->willReturn("");
         $sut = new RouteRegistry();
         $sut->addGet($givenRoute, $handlerSpy);
         $registeredHandler = $sut->fromGet($givenRoute);
-        $registeredHandler->handle(new ConfigurableContainerStub(new ContainerConfigurationStub()));
+        $registeredHandler->getResponseContent(new ConfigurableContainerStub(new ContainerConfigurationStub()));
     }
 
     #[TestDox("Shall retrieve the request handlers associated with a POST request")]
@@ -35,14 +35,14 @@ final class RouteRegistryTest extends TestCase
     {
         $givenRoute = "/";
         /**
-         * @var MockObject&AbstractRouteDelegate $handlerSpy
+         * @var MockObject&AbstractContentDelegate $handlerSpy
          */
-        $handlerSpy = $this->getMockForAbstractClass(AbstractRouteDelegate::class);
-        $handlerSpy->expects($this->once())->method("handle")->willReturn("");
+        $handlerSpy = $this->getMockForAbstractClass(AbstractContentDelegate::class);
+        $handlerSpy->expects($this->once())->method("getResponseContent")->willReturn("");
         $sut = new RouteRegistry();
         $sut->addPost($givenRoute, $handlerSpy);
         $registeredHandler = $sut->fromPost($givenRoute);
-        $registeredHandler->handle(new ConfigurableContainerStub(new ContainerConfigurationStub()));
+        $registeredHandler->getResponseContent(new ConfigurableContainerStub(new ContainerConfigurationStub()));
     }
 
     #[TestDox("Shall return a RouteNotRegistered instance when a route is not associated with any handlers.")]
@@ -60,9 +60,9 @@ final class RouteRegistryTest extends TestCase
     {
         $givenRoute = "/";
         /**
-         * @var Stub&AbstractRouteDelegate $handlerSpy
+         * @var Stub&AbstractContentDelegate $handlerSpy
          */
-        $handlerSpy = $this->createStub(AbstractRouteDelegate::class);
+        $handlerSpy = $this->createStub(AbstractContentDelegate::class);
         $sut = new RouteRegistry();
         $sut->addGet($givenRoute, $handlerSpy);
         $result = $sut->fromPost($givenRoute);
@@ -74,9 +74,9 @@ final class RouteRegistryTest extends TestCase
     {
         $givenRoute = "/";
         /**
-         * @var Stub&AbstractRouteDelegate $handlerSpy
+         * @var Stub&AbstractContentDelegate $handlerSpy
          */
-        $handlerSpy = $this->createStub(AbstractRouteDelegate::class);
+        $handlerSpy = $this->createStub(AbstractContentDelegate::class);
         $sut = new RouteRegistry();
         $sut->addPost($givenRoute, $handlerSpy);
         $result = $sut->fromGet($givenRoute);

--- a/tests/unit/WebServer/WebServerTest.php
+++ b/tests/unit/WebServer/WebServerTest.php
@@ -10,7 +10,7 @@ use Phpolar\CsrfProtection\Http\CsrfPostRoutingMiddleware;
 use Phpolar\CsrfProtection\Http\CsrfPostRoutingMiddlewareFactory;
 use Phpolar\CsrfProtection\Http\CsrfPreRoutingMiddleware;
 use Phpolar\HttpCodes\ResponseCode;
-use Phpolar\Phpolar\Routing\AbstractRouteDelegate;
+use Phpolar\Phpolar\Routing\AbstractContentDelegate;
 use Phpolar\Phpolar\Routing\RouteRegistry;
 use Phpolar\Phpolar\Tests\Stubs\ConfigurableContainerStub;
 use Phpolar\Phpolar\Tests\Stubs\ContainerConfigurationStub;
@@ -23,7 +23,6 @@ use Phpolar\PurePhp\Dispatcher;
 use Phpolar\PurePhp\StreamContentStrategy;
 use Phpolar\PurePhp\TemplatingStrategyInterface;
 use PHPUnit\Framework\Attributes\CoversClass;
-use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\Attributes\RunTestsInSeparateProcesses;
 use PHPUnit\Framework\Attributes\TestDox;
 use PHPUnit\Framework\Attributes\UsesClass;
@@ -298,11 +297,11 @@ final class WebServerTest extends TestCase
         $givenRoutes = new RouteRegistry();
         $givenRoutes->addPost(
             $givenPath,
-            new class ($expectedResponse) extends AbstractRouteDelegate {
+            new class ($expectedResponse) extends AbstractContentDelegate {
                 public function __construct(private string $expectedResponse)
                 {
                 }
-                public function handle(ContainerInterface $container): string
+                public function getResponseContent(ContainerInterface $container): string
                 {
                     return $this->expectedResponse;
                 }


### PR DESCRIPTION
The previous name did not clearly indicate that the response content was expected to be returned.