### PR TITLE
fix: use 404 error handler

### DIFF
--- a/config/dependencies/framework.php
+++ b/config/dependencies/framework.php
@@ -48,7 +48,7 @@ return [
         $config[RouteRegistry::class],
         $config[ResponseFactoryInterface::class],
         $config[StreamFactoryInterface::class],
-        $config[WebServer::ERROR_HANDLER_401],
+        $config[WebServer::ERROR_HANDLER_404],
         $config[ContainerInterface::class],
     ),
     /**


### PR DESCRIPTION
The routing handler should use the 404 handler instead of 401.