### PR TITLE
fix(AbstractModel): all iteration over all public properties

### DIFF
--- a/src/Model/AbstractModel.php
+++ b/src/Model/AbstractModel.php
@@ -4,17 +4,24 @@ declare(strict_types=1);
 
 namespace Phpolar\Phpolar\Model;
 
+use DateTime;
+use DateTimeImmutable;
+use DateTimeInterface;
+use IteratorAggregate;
 use ReflectionIntersectionType;
 use ReflectionNamedType;
 use ReflectionObject;
 use ReflectionProperty;
+use Traversable;
 use TypeError;
 
 /**
  * Provides support for configuring the properties
  * of an object for validation, formatting, and storage.
+ *
+ * @template-implements IteratorAggregate<string,mixed>
  */
-abstract class AbstractModel
+abstract class AbstractModel implements IteratorAggregate
 {
     use ColumnNameTrait;
     use DataTypeDetectionTrait;
@@ -52,6 +59,9 @@ abstract class AbstractModel
                                 "float" => (float) $val,
                                 "bool" => (bool) $val,
                                 "string" => $val,
+                                DateTime::class => new DateTime($val),
+                                DateTimeInterface::class,
+                                DateTimeImmutable::class => new DateTimeImmutable($val),
                                 default => throw new TypeError(
                                     "Cannot automatically set string source values to non-scalar
                                      target properties.  Set the property manually."
@@ -60,10 +70,50 @@ abstract class AbstractModel
                             default => $val,
                         };
                         $prop->setValue($this, $casted);
+                        continue;
                     }
                     $prop->setValue($this, $val);
                 }
             }
+        }
+    }
+
+    /**
+     * @return Traversable<string,mixed>
+     */
+    public function getIterator(): Traversable
+    {
+        /**
+         * We only want public properties
+         * so we are using this other
+         * object. Yeah, we could have
+         * used Reflection. But there's
+         * more than one way to get
+         * public properties off an
+         * object.
+         */
+        $anotherWay = new class () {
+            /**
+             * Get the public properties.
+             *
+             * @return array<string,mixed>
+             */
+            public function getPubProps(object $model): array
+            {
+                return array_merge(
+                    get_class_vars($model::class),
+                    get_object_vars($model)
+                );
+            }
+        };
+        /**
+         * Iteration over models needs
+         * to support iteration of non-initialized
+         * public properties.
+         */
+        $allPublicProps = $anotherWay->getPubProps($this);
+        foreach ($allPublicProps as $propName => $propVal) {
+            yield $propName => $propVal;
         }
     }
 }

--- a/tests/unit/Model/AbstractModelTest.php
+++ b/tests/unit/Model/AbstractModelTest.php
@@ -5,6 +5,8 @@ declare(strict_types=1);
 namespace Phpolar\Phpolar\Model;
 
 use ArrayAccess;
+use DateTime;
+use DateTimeImmutable;
 use DateTimeInterface;
 use TypeError;
 use PHPUnit\Framework\Attributes\CoversClass;
@@ -147,17 +149,56 @@ final class AbstractModelTest extends TestCase
             "prop2" => "1.0",
             "prop3" => "1",
             "prop4" => "my string",
+            "date" => "now",
+            "dateImm" => "yesterday",
+            "dateInt" => "100 years ago",
         ];
         $model = new class ($stringVals) extends AbstractModel {
             public int $prop1;
             public float $prop2;
             public bool $prop3;
             public string $prop4;
+            public DateTime $date;
+            public DateTimeImmutable $dateImm;
+            public DateTimeInterface $dateInt;
         };
         $this->assertSame(1, $model->prop1);
         $this->assertSame(1.0, $model->prop2);
         $this->assertTrue($model->prop3);
         $this->assertSame("my string", $model->prop4);
+        $this->assertInstanceOf(DateTime::class, $model->date);
+        $this->assertInstanceOf(DateTimeImmutable::class, $model->dateImm);
+        $this->assertInstanceOf(DateTimeInterface::class, $model->dateInt);
+    }
+
+    #[TestDox("Shall convert given string values from source array to the declared type of the target model")]
+    public function test6bb()
+    {
+        $stringVals = (object) [
+            "prop1" => "1",
+            "prop2" => "1.0",
+            "prop3" => "1",
+            "prop4" => "my string",
+            "date" => "now",
+            "dateImm" => "yesterday",
+            "dateInt" => "100 years ago",
+        ];
+        $model = new class ($stringVals) extends AbstractModel {
+            public int $prop1;
+            public float $prop2;
+            public bool $prop3;
+            public string $prop4;
+            public DateTime $date;
+            public DateTimeImmutable $dateImm;
+            public DateTimeInterface $dateInt;
+        };
+        $this->assertSame(1, $model->prop1);
+        $this->assertSame(1.0, $model->prop2);
+        $this->assertTrue($model->prop3);
+        $this->assertSame("my string", $model->prop4);
+        $this->assertInstanceOf(DateTime::class, $model->date);
+        $this->assertInstanceOf(DateTimeImmutable::class, $model->dateImm);
+        $this->assertInstanceOf(DateTimeInterface::class, $model->dateInt);
     }
 
     #[TestDox("Shall throw an exception when intersection type is declared")]
@@ -251,5 +292,21 @@ final class AbstractModelTest extends TestCase
         new class ($stringVals) extends AbstractModel {
             public array $prop1;
         };
+    }
+
+    #[TestDox("Shall support iteration over non-initialized public properties")]
+    public function testa()
+    {
+        $sut = new class extends AbstractModel {
+            public string $name;
+            public string $address;
+        };
+        $iterated = false;
+        foreach ($sut as $propName => $propVal) {
+            $this->assertContains($propName, ["name", "address"]);
+            $this->assertNull($propVal);
+            $iterated = true;
+        }
+        $this->assertTrue($iterated, "Did not iterate over the object.");
     }
 }


### PR DESCRIPTION
Non-initialized properties were not included in iteration.  This commit also fixes setting of DateTimeInterface properties.

Fixes #123 