### PR TITLE
feat: pass psr 11 container instead of config array

### DIFF
--- a/config/dependencies/framework.php
+++ b/config/dependencies/framework.php
@@ -28,35 +28,35 @@ return [
     /**
      * @suppress PhanUnreferencedClosure
      */
-    WebServer::ERROR_HANDLER_401 => static fn (ArrayAccess $config) => new ErrorHandler(
+    WebServer::ERROR_HANDLER_401 => static fn (ContainerInterface $container) => new ErrorHandler(
         ResponseCode::UNAUTHORIZED,
         "Unauthorized",
-        $config[ContainerInterface::class],
+        $container,
     ),
     /**
      * @suppress PhanUnreferencedClosure
      */
-    WebServer::ERROR_HANDLER_404 => static fn (ArrayAccess $config) => new ErrorHandler(
+    WebServer::ERROR_HANDLER_404 => static fn (ContainerInterface $container) => new ErrorHandler(
         ResponseCode::NOT_FOUND,
         "Not Found",
-        $config[ContainerInterface::class],
+        $container,
     ),
     /**
      * @suppress PhanUnreferencedClosure
      */
-    RoutingHandler::class => static fn (ArrayAccess $config) => new RoutingHandler(
-        $config[RouteRegistry::class],
-        $config[ResponseFactoryInterface::class],
-        $config[StreamFactoryInterface::class],
-        $config[WebServer::ERROR_HANDLER_404],
-        $config[ContainerInterface::class],
+    RoutingHandler::class => static fn (ContainerInterface $container) => new RoutingHandler(
+        $container->get(RouteRegistry::class),
+        $container->get(ResponseFactoryInterface::class),
+        $container->get(StreamFactoryInterface::class),
+        $container->get(WebServer::ERROR_HANDLER_404),
+        $container,
     ),
     /**
      * @suppress PhanUnreferencedClosure
      */
-    PrimaryHandler::class => static fn (ArrayAccess $config) => new PrimaryHandler($config[WebServer::ERROR_HANDLER_404]),
+    PrimaryHandler::class => static fn (ContainerInterface $container) => new PrimaryHandler($container->get(WebServer::ERROR_HANDLER_404)),
     /**
      * @suppress PhanUnreferencedClosure
      */
-    RoutingMiddleware::class => static fn (ArrayAccess $config) => new RoutingMiddleware($config[RoutingHandler::class])
+    RoutingMiddleware::class => static fn (ContainerInterface $container) => new RoutingMiddleware($container->get(RoutingHandler::class))
 ];

--- a/src/WebServer/ContainerManager.php
+++ b/src/WebServer/ContainerManager.php
@@ -35,8 +35,8 @@ final class ContainerManager
         AbstractContainerFactory $containerFac,
         ArrayAccess $containerConfig
     ) {
-        $this->containerLoader = new ContainerLoader($containerConfig);
         $this->container = $containerFac->getContainer($containerConfig);
+        $this->containerLoader = new ContainerLoader($containerConfig, $this->container);
     }
 
     /**

--- a/src/WebServer/WebServer.php
+++ b/src/WebServer/WebServer.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Phpolar\Phpolar\WebServer;
 
-use ArrayAccess;
 use Phpolar\Extensions\HttpResponse\ResponseExtension;
 use Phpolar\Phpolar\Routing\RouteRegistry;
 use Phpolar\Phpolar\WebServer\Http\MiddlewareQueueInterface;
@@ -20,43 +19,26 @@ final class WebServer
     public const ERROR_HANDLER_401 = "ERROR_HANDLER_401";
     public const ERROR_HANDLER_404 = "ERROR_HANDLER_404";
 
-    private ContainerManager $containerManager;
-
     private RequestHandlerInterface&MiddlewareQueueInterface $primaryHandler;
 
     /**
      * Prevent creation of multiple instances.
-     *
-     * @param AbstractContainerFactory $containerFac
-     * @param ArrayAccess<string,mixed> $containerConfig
      */
     private function __construct(
-        AbstractContainerFactory $containerFac,
-        ArrayAccess $containerConfig,
+        private ContainerManager $containerManager,
     ) {
-        $this->containerManager = new ContainerManager($containerFac, $containerConfig);
         $this->primaryHandler = $this->containerManager->getPrimaryHandler();
     }
 
     /**
      * Creates a singleton web server application.  This framework targets the
      * *stateless, single-threaded, server-side application use case*.  Therefore,
-     * only a single instance is created on each request.  If the provided
-     * factory used to create the dependency injection container is stateless,
-     * caching this instance should be considered for performance reasons.
-     *
-     * @param AbstractContainerFactory $containerFactory Adds support for configuring
-     * a **PSR-11** dependency injection container before the app is initialized, afterwards,
-     * or both.
-     *
-     * @param ArrayAccess<string,mixed> $containerConfig The framework will configure some
-     * services/dependencies after the application is initialized.
+     * only a single instance is created on each request.
      */
     public static function createApp(
-        AbstractContainerFactory $containerFactory,
-        ArrayAccess $containerConfig,
+        ContainerManager $containerManager,
     ): WebServer {
-        return new self($containerFactory, $containerConfig);
+        return new self($containerManager);
     }
 
     /**

--- a/tests/__fakes__/src/config/dependencies/conf.d/fake-custom.php
+++ b/tests/__fakes__/src/config/dependencies/conf.d/fake-custom.php
@@ -1,7 +1,6 @@
 <?php
 
 use Phpolar\HttpCodes\ResponseCode;
-use Phpolar\Phpolar\Tests\Stubs\ConfigurableContainerStub;
 use Phpolar\Phpolar\Tests\Stubs\ResponseFactoryStub;
 use Phpolar\Phpolar\Tests\Stubs\StreamFactoryStub;
 use Phpolar\Phpolar\WebServer\Http\ErrorHandler;
@@ -17,19 +16,18 @@ use Psr\Http\Message\ResponseFactoryInterface;
 use Psr\Http\Message\StreamFactoryInterface;
 
 return [
-    PrimaryHandler::class => static fn (ArrayAccess $config) => new PrimaryHandler($config[WebServer::ERROR_HANDLER_404]),
-    WebServer::ERROR_HANDLER_401 => static fn (ArrayAccess $config) => new ErrorHandler(
+    PrimaryHandler::class => static fn (ContainerInterface $container) => new PrimaryHandler($container->get(WebServer::ERROR_HANDLER_404)),
+    WebServer::ERROR_HANDLER_401 => static fn (ContainerInterface $container) => new ErrorHandler(
         ResponseCode::UNAUTHORIZED,
         "Unauthorized",
-        $config[ContainerInterface::class],
+        $container,
     ),
-    WebServer::ERROR_HANDLER_404 => static fn (ArrayAccess $config) => new ErrorHandler(
+    WebServer::ERROR_HANDLER_404 => static fn (ContainerInterface $container) => new ErrorHandler(
         ResponseCode::NOT_FOUND,
         "Not Found",
-        $config[ContainerInterface::class],
+        $container,
     ),
-    TemplateEngine::class => static fn (ArrayAccess $config) => new TemplateEngine($config[TemplatingStrategyInterface::class], new Binder(), new Dispatcher()),
-    ContainerInterface::class => static fn (ArrayAccess $config) => new ConfigurableContainerStub($config),
+    TemplateEngine::class => static fn (ContainerInterface $container) => new TemplateEngine($container->get(TemplatingStrategyInterface::class), new Binder(), new Dispatcher()),
     TemplatingStrategyInterface::class => new StreamContentStrategy(),
     ResponseFactoryInterface::class => new ResponseFactoryStub(),
     StreamFactoryInterface::class => new StreamFactoryStub(),

--- a/tests/unit/WebServer/WebServerTest.php
+++ b/tests/unit/WebServer/WebServerTest.php
@@ -125,7 +125,7 @@ final class WebServerTest extends TestCase
         $containerFac = $this->getContainerFactory($config, $handler);
         // do not use the container config file
         chdir(__DIR__);
-        $server = WebServer::createApp($containerFac, $config);
+        $server = WebServer::createApp(new ContainerManager($containerFac, $config));
         $server->useRoutes($routes);
         $server->receive($request);
         $this->assertSame(ResponseCode::OK, http_response_code());
@@ -185,7 +185,7 @@ final class WebServerTest extends TestCase
         $containerFac = $this->getContainerFactory($config, $handler, $csrfPreRoutingMiddleware, $csrfPostRoutingMiddleware);
         // do not use the container config file
         chdir(__DIR__);
-        $server = WebServer::createApp($containerFac, $config);
+        $server = WebServer::createApp(new ContainerManager($containerFac, $config));
         $server->useCsrfMiddleware();
         $server->useRoutes($routes);
         $server->receive($request);
@@ -208,7 +208,7 @@ final class WebServerTest extends TestCase
         $config = new ContainerConfigurationStub();
         $containerFac = $this->getContainerFactory($config, $handlerStub);
         $container = $containerFac->getContainer($config);
-        $sut = WebServer::createApp($containerFac, $config);
+        $sut = WebServer::createApp(new ContainerManager($containerFac, $config));
         $sut->useRoutes($givenRoutes);
         /**
          * @var RouteRegistry $configuredRoutes
@@ -227,7 +227,7 @@ final class WebServerTest extends TestCase
         $config[ResponseFactoryInterface::class] = $this->createStub(ResponseFactoryInterface::class);
         $nonConfiguredContainerFac = $this->getNonConfiguredContainer();
         chdir("tests/__fakes__/");
-        $app = WebServer::createApp($nonConfiguredContainerFac, $config);
+        $app = WebServer::createApp(new ContainerManager($nonConfiguredContainerFac, $config));
         $app->receive(new RequestStub());
         $this->expectOutputString("<h1>Not Found</h1>");
     }
@@ -243,7 +243,7 @@ final class WebServerTest extends TestCase
         $handlerStub = $this->createStub(PrimaryHandler::class);
         $handlerStub->method("handle")->willReturn((new ResponseStub(404, "Not Found")));
         $container = $this->getContainerFactory($config, $handlerStub);
-        $sut = WebServer::createApp($container, $config);
+        $sut = WebServer::createApp(new ContainerManager($container, $config));
         $sut->receive(new RequestStub("GET", "/non-existing-route"));
         $this->assertSame(ResponseCode::NOT_FOUND, http_response_code());
     }


### PR DESCRIPTION
The container should be readonly after the application is bootstrapped.  Using a PSR-11 container in dependency injection configurations will improve interoperability and ease-of-use.

Resolves #122, Closes #122