### PR TITLE
refactor(RoutingHandler): use type doc annotation instead of casting …

### DIFF
--- a/src/Routing/RoutingHandler.php
+++ b/src/Routing/RoutingHandler.php
@@ -61,7 +61,10 @@ class RoutingHandler implements RequestHandlerInterface
     {
         $reflectionMethod = new ReflectionMethod($resolvedRoute->delegate, "getResponseContent");
         $args = array_merge([$this->container], $resolvedRoute->routeParamMap->toArray());
+        /**
+         * @var string $responseContent
+         */
         $responseContent = $reflectionMethod->invokeArgs($resolvedRoute->delegate, $args);
-        return $this->getResponse(strval($responseContent));
+        return $this->getResponse($responseContent);
     }
 }


### PR DESCRIPTION
…with strval

The signature of the invoked method requires a return string.  The annotation is only used because the method is invoked using reflection.