### PR TITLE
fix(AbstractModel): add null to constructor parameter type hint

### DIFF
--- a/src/Model/AbstractModel.php
+++ b/src/Model/AbstractModel.php
@@ -37,7 +37,7 @@ abstract class AbstractModel implements IteratorAggregate
     /**
      * @param array<string|int,mixed>|object $data
      */
-    public function __construct(array | object $data = [])
+    public function __construct(null | array | object $data = [])
     {
         if (empty($data) === false) {
             $publicProps = (new ReflectionObject($this))->getProperties(ReflectionProperty::IS_PUBLIC);


### PR DESCRIPTION
This accounts for PSR-7 version 2 explicitly allowing null parsed request bodies.