### PR TITLE
ci: remove static analysis in ci job

### DIFF
--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -36,9 +36,6 @@ jobs:
     - name: Scanning for lint errors
       run: composer ci:lint
 
-    - name: Run static analysis
-      run: composer ci:analyze
-
     - name: Run test suite
       run: composer ci:test
 


### PR DESCRIPTION
The jobs were failing.  The error is not critical.