### PR TITLE
fix: prune dist

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -4,6 +4,7 @@
 /composer.lock              export-ignore
 /.cz.yaml                   export-ignore
 /docs                       export-ignore
+/bin                        export-ignore
 /examples                   export-ignore
 /.gitattributes             export-ignore
 /.github                    export-ignore


### PR DESCRIPTION
Users of the library do not need the scripts in the bin folder.

Closes #193