### PR TITLE
docs(App): fix method comment

### DIFF
--- a/docs/classes/Phpolar-Phpolar-App.html
+++ b/docs/classes/Phpolar-Phpolar-App.html
@@ -244,7 +244,7 @@ only a single instance is created on each request.</p>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="App.php"><a href="files/app.html"><abbr title="App.php">App.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">59</span>
+    <span class="phpdocumentor-element-found-in__line">56</span>
 
     </aside>
 
@@ -254,10 +254,7 @@ only a single instance is created on each request.</p>
     <span class="phpdocumentor-signature__visibility">public</span>
                     <span class="phpdocumentor-signature__name">receive</span><span>(</span><span class="phpdocumentor-signature__argument"><span class="phpdocumentor-signature__argument__return-type"><abbr title="\Psr\Http\Message\ServerRequestInterface">ServerRequestInterface</abbr>&nbsp;</span><span class="phpdocumentor-signature__argument__name">$request</span></span><span>)</span><span> : </span><span class="phpdocumentor-signature__response_type">void</span></code>
 
-        <section class="phpdocumentor-description"><p>If <code class="prettyprint">useRoutes</code> is not called before this method,
-a 401 &quot;Not Found&quot; response will be produced.</p>
-</section>
-
+    
         <h5 class="phpdocumentor-argument-list__heading">Parameters</h5>
     <dl class="phpdocumentor-argument-list">
                     <dt class="phpdocumentor-argument-list__entry">
@@ -291,7 +288,7 @@ a 401 &quot;Not Found&quot; response will be produced.</p>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="App.php"><a href="files/app.html"><abbr title="App.php">App.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">103</span>
+    <span class="phpdocumentor-element-found-in__line">100</span>
 
     </aside>
 
@@ -340,7 +337,7 @@ will be set up for CSRF detection.</p>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="App.php"><a href="files/app.html"><abbr title="App.php">App.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">77</span>
+    <span class="phpdocumentor-element-found-in__line">74</span>
 
     </aside>
 

--- a/src/App.php
+++ b/src/App.php
@@ -52,9 +52,6 @@ final class App
 
     /**
      * Handle and respond to requests from clients.
-     *
-     * If `useRoutes` is not called before this method,
-     * a 401 "Not Found" response will be produced.
      */
     public function receive(ServerRequestInterface $request): void
     {


### PR DESCRIPTION
Calling `useRoutes` is no longer required.