### PR TITLE
docs(App): fix method comment

### DIFF
--- a/docs/classes/Phpolar-Phpolar-App.html
+++ b/docs/classes/Phpolar-Phpolar-App.html
@@ -288,7 +288,7 @@ only a single instance is created on each request.</p>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="App.php"><a href="files/app.html"><abbr title="App.php">App.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">100</span>
+    <span class="phpdocumentor-element-found-in__line">97</span>
 
     </aside>
 
@@ -301,8 +301,6 @@ only a single instance is created on each request.</p>
         <section class="phpdocumentor-description"><p>The server will not process the request if the
 CSRF check fails.  The current response
 will be set up for CSRF detection.</p>
-<p>Must be called directly before the
-<code class="prettyprint">useRoutes</code> method is called.</p>
 </section>
 
         <h5 class="phpdocumentor-argument-list__heading">Parameters</h5>

--- a/src/App.php
+++ b/src/App.php
@@ -92,9 +92,6 @@ final class App
      * CSRF check fails.  The current response
      * will be set up for CSRF detection.
      *
-     * Must be called directly before the
-     * `useRoutes` method is called.
-     *
      * @param array<string,bool|int|float|string> $sessionOpts
      */
     public function useCsrfMiddleware(


### PR DESCRIPTION
Calling `useRoutes` is no longer required.