### PR TITLE
ci: allow ci job failure

### DIFF
--- a/.github/workflows/php-latest.yml
+++ b/.github/workflows/php-latest.yml
@@ -7,6 +7,7 @@ on:
 jobs:
   build:
     runs-on: ${{ matrix.operating-system }}
+    continue-on-error: true
     strategy:
       matrix:
         operating-system: ['ubuntu-22.04', 'ubuntu-20.04', 'windows-latest', 'macos-latest']


### PR DESCRIPTION
`laminas/laminas-httphandlerrunner ^2.6` does not support PHP 8.3.