### PR TITLE
refactor(RoutableInterface): move interface out of http namespace

### DIFF
--- a/.phan/config_deadcode.php
+++ b/.phan/config_deadcode.php
@@ -267,6 +267,8 @@ return [
         'PhanPluginNoCommentOnProtectedProperty',
         'PhanPluginNoCommentOnPrivateMethod',
         'PhanPluginDescriptionlessCommentOnPrivateMethod',
+        // does not support contrariance
+        'PhanTypeMismatchArgumentSuperType',
         // does not support covariance
         'PhanTypeMismatchReturnSuperType'
     ],

--- a/src/Auth/AbstractProtectedRoutable.php
+++ b/src/Auth/AbstractProtectedRoutable.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Phpolar\Phpolar\Auth;
 
-use Phpolar\Phpolar\Http\RoutableInterface;
+use Phpolar\Phpolar\RoutableInterface;
 
 /**
  * Represents an authenticated request delegate
@@ -18,6 +18,10 @@ abstract class AbstractProtectedRoutable implements RoutableInterface
      */
     public User $user;
 
+    /**
+     * Create a `User` from the given session
+     * and assign it to the user property.
+     */
     public function withUser(object $session): self
     {
         $copy = clone $this;

--- a/src/Auth/Authenticate.php
+++ b/src/Auth/Authenticate.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace Phpolar\Phpolar\Auth;
 
 use Attribute;
-use Phpolar\Phpolar\Http\RoutableInterface;
+use Phpolar\Phpolar\RoutableInterface;
 
 /**
  * Provides an authentication mechanism

--- a/src/Auth/AuthenticatorInterface.php
+++ b/src/Auth/AuthenticatorInterface.php
@@ -10,5 +10,9 @@ namespace Phpolar\Phpolar\Auth;
  */
 interface AuthenticatorInterface
 {
+    /**
+     * Returns user information from
+     * the authenticated session.
+     */
     public function getCredentials(): ?object;
 }

--- a/src/Auth/ProtectedRoutableResolver.php
+++ b/src/Auth/ProtectedRoutableResolver.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Phpolar\Phpolar\Auth;
 
-use Phpolar\Phpolar\Http\RoutableInterface;
+use Phpolar\Phpolar\RoutableInterface;
 use Phpolar\Phpolar\RoutableResolverInterface;
 use ReflectionMethod;
 use ReflectionAttribute;

--- a/src/Http/ResolvedRoute.php
+++ b/src/Http/ResolvedRoute.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Phpolar\Phpolar\Http;
 
+use Phpolar\Phpolar\RoutableInterface;
 use Phpolar\Phpolar\Core\Routing\RouteParamMap;
 
 /**

--- a/src/Http/RouteRegistry.php
+++ b/src/Http/RouteRegistry.php
@@ -6,6 +6,7 @@ namespace Phpolar\Phpolar\Http;
 
 use DomainException;
 use Psr\Http\Message\ServerRequestInterface;
+use Phpolar\Phpolar\RoutableInterface;
 use Phpolar\Phpolar\Core\Routing\RouteNotRegistered;
 use Phpolar\Phpolar\Core\Routing\RouteParamMap;
 

--- a/src/Http/RoutingHandler.php
+++ b/src/Http/RoutingHandler.php
@@ -6,6 +6,7 @@ namespace Phpolar\Phpolar\Http;
 
 use Phpolar\ModelResolver\ModelResolverInterface;
 use Phpolar\Phpolar\Core\Routing\RouteNotRegistered;
+use Phpolar\Phpolar\RoutableInterface;
 use Phpolar\Phpolar\RoutableResolverInterface;
 use Psr\Container\ContainerInterface;
 use Psr\Http\Message\ResponseFactoryInterface;

--- a/src/RoutableInterface.php
+++ b/src/RoutableInterface.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Phpolar\Phpolar\Http;
+namespace Phpolar\Phpolar;
 
 use Psr\Container\ContainerInterface;
 

--- a/src/RoutableResolverInterface.php
+++ b/src/RoutableResolverInterface.php
@@ -4,9 +4,6 @@ declare(strict_types=1);
 
 namespace Phpolar\Phpolar;
 
-use Phpolar\Phpolar\Auth\AbstractProtectedRoutable;
-use Phpolar\Phpolar\Http\RoutableInterface;
-
 /**
  * Used by the application to determine which
  * routable/handler to use.  This can be

--- a/tests/__fakes__/src/config/dependencies/conf.d/fake-custom.php
+++ b/tests/__fakes__/src/config/dependencies/conf.d/fake-custom.php
@@ -9,7 +9,7 @@ use Phpolar\Phpolar\Auth\AuthenticatorInterface;
 use Phpolar\Phpolar\Http\ErrorHandler;
 use Phpolar\Phpolar\Http\MiddlewareQueueRequestHandler;
 use Phpolar\Phpolar\DependencyInjection\DiTokens;
-use Phpolar\Phpolar\Http\RoutableInterface;
+use Phpolar\Phpolar\RoutableInterface;
 use Phpolar\Phpolar\Http\RouteRegistry;
 use Phpolar\Phpolar\Http\RoutingHandler;
 use Phpolar\Phpolar\Http\RoutingMiddleware;

--- a/tests/acceptance/MemoryUsageTest.php
+++ b/tests/acceptance/MemoryUsageTest.php
@@ -18,7 +18,7 @@ use Phpolar\HttpMessageTestUtils\RequestStub;
 use Phpolar\HttpMessageTestUtils\ResponseFactoryStub;
 use Phpolar\HttpMessageTestUtils\StreamFactoryStub;
 use Phpolar\ModelResolver\ModelResolverInterface;
-use Phpolar\Phpolar\Http\RoutableInterface;
+use Phpolar\Phpolar\RoutableInterface;
 use Phpolar\Phpolar\Http\RouteRegistry;
 use Phpolar\Phpolar\Http\RoutingHandler;
 use Phpolar\Phpolar\Http\RoutingMiddleware;

--- a/tests/acceptance/RoutingTest.php
+++ b/tests/acceptance/RoutingTest.php
@@ -12,6 +12,7 @@ use Phpolar\HttpMessageTestUtils\ResponseStub;
 use Phpolar\HttpMessageTestUtils\UriStub;
 use Phpolar\ModelResolver\ModelResolverInterface;
 use Phpolar\Phpolar\RoutableResolverInterface;
+use Phpolar\Phpolar\RoutableInterface;
 use Phpolar\PurePhp\Binder;
 use Phpolar\PurePhp\Dispatcher;
 use Phpolar\PurePhp\StreamContentStrategy;

--- a/tests/unit/AppTest.php
+++ b/tests/unit/AppTest.php
@@ -23,7 +23,6 @@ use Phpolar\ModelResolver\ModelResolverInterface;
 use Phpolar\Phpolar\Auth\AuthenticatorInterface;
 use Phpolar\Phpolar\DependencyInjection\ContainerLoader;
 use Phpolar\Phpolar\DependencyInjection\DiTokens;
-use Phpolar\Phpolar\Http\RoutableInterface;
 use Phpolar\Phpolar\Http\RouteRegistry;
 use Phpolar\Phpolar\Http\RoutingMiddleware;
 use Phpolar\Phpolar\Tests\Stubs\ConfigurableContainerStub;

--- a/tests/unit/Auth/AuthenticateTest.php
+++ b/tests/unit/Auth/AuthenticateTest.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace Phpolar\Phpolar\Auth;
 
 use Generator;
-use Phpolar\Phpolar\Http\RoutableInterface;
+use Phpolar\Phpolar\RoutableInterface;
 use Phpolar\Phpolar\Tests\Stubs\ConfigurableContainerStub;
 use Phpolar\Phpolar\Tests\Stubs\ContainerConfigurationStub;
 use PHPUnit\Framework\Attributes\CoversClass;

--- a/tests/unit/Auth/ProtectedRoutableResolverTest.php
+++ b/tests/unit/Auth/ProtectedRoutableResolverTest.php
@@ -8,6 +8,7 @@ use Phpolar\Phpolar\Auth\AbstractProtectedRoutable;
 use Phpolar\Phpolar\Auth\Authenticate;
 use Phpolar\Phpolar\Auth\AuthenticatorInterface;
 use Phpolar\Phpolar\Auth\ProtectedRoutableResolver;
+use Phpolar\Phpolar\RoutableInterface;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\TestDox;
 use PHPUnit\Framework\MockObject\Stub;

--- a/tests/unit/Http/RouteRegistryTest.php
+++ b/tests/unit/Http/RouteRegistryTest.php
@@ -9,6 +9,7 @@ use Generator;
 use Phpolar\HttpMessageTestUtils\RequestStub;
 use Phpolar\Phpolar\Core\Routing\RouteNotRegistered;
 use Phpolar\Phpolar\Core\Routing\RouteParamMap;
+use Phpolar\Phpolar\RoutableInterface;
 use Phpolar\Phpolar\Tests\Stubs\ConfigurableContainerStub;
 use Phpolar\Phpolar\Tests\Stubs\ContainerConfigurationStub;
 use PHPUnit\Framework\Attributes\CoversClass;

--- a/tests/unit/Http/RoutingHandlerTest.php
+++ b/tests/unit/Http/RoutingHandlerTest.php
@@ -17,6 +17,7 @@ use Phpolar\Phpolar\Auth\AbstractProtectedRoutable;
 use Phpolar\Phpolar\Core\Routing\RouteNotRegistered;
 use Phpolar\Phpolar\Core\Routing\RouteParamMap;
 use Phpolar\Phpolar\Http\ErrorHandler;
+use Phpolar\Phpolar\RoutableInterface;
 use Phpolar\Phpolar\RoutableResolverInterface;
 use Phpolar\PurePhp\Binder;
 use Phpolar\PurePhp\Dispatcher;


### PR DESCRIPTION
Moving this into the root namespace prevents objects in the `Http` and `Auth` namespaces from having cross-dependencies.  The interfaces may be moved into their own projects soon.