### PR TITLE
fix: add support for configurable unauthorized handlers

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -35,4 +35,4 @@ repos:
     hooks:
       # Hooks using native
       - id: phpmd # static analyzer for PHP code
-        exclude: (examples|tests|config|src\/Http\/ErrorHandler\.php$)
+        exclude: (examples|tests|config|src\/Http\/ErrorHandler\.php|src\/Http\/RoutingHandler\.php$)

--- a/config/dependencies/framework.php
+++ b/config/dependencies/framework.php
@@ -55,6 +55,7 @@ return [
         modelResolver: $container->get(ModelResolverInterface::class),
         container: $container,
         routableResolver: $container->get(RoutableResolverInterface::class),
+        unauthHandler: $container->get(DiTokens::UNAUTHORIZED_HANDLER),
     ),
     /**
      * @suppress PhanUnreferencedClosure

--- a/src/DependencyInjection/DiTokens.php
+++ b/src/DependencyInjection/DiTokens.php
@@ -14,4 +14,5 @@ final class DiTokens
     public const ERROR_HANDLER_401 = "ERROR_HANDLER_401";
     public const ERROR_HANDLER_404 = "ERROR_HANDLER_404";
     public const RESPONSE_EMITTER = "RESPONSE_EMITTER";
+    public const UNAUTHORIZED_HANDLER = "UNAUTHORIZED_HANDLER";
 }

--- a/tests/__fakes__/src/config/dependencies/conf.d/fake-custom.php
+++ b/tests/__fakes__/src/config/dependencies/conf.d/fake-custom.php
@@ -3,6 +3,7 @@
 use Laminas\HttpHandlerRunner\Emitter\SapiEmitter;
 use Phpolar\HttpCodes\ResponseCode;
 use Phpolar\HttpMessageTestUtils\ResponseFactoryStub;
+use Phpolar\HttpMessageTestUtils\ResponseStub;
 use Phpolar\HttpMessageTestUtils\StreamFactoryStub;
 use Phpolar\ModelResolver\ModelResolverInterface;
 use Phpolar\Phpolar\Auth\AuthenticatorInterface;
@@ -21,7 +22,10 @@ use Phpolar\PurePhp\TemplateEngine;
 use Phpolar\PurePhp\TemplatingStrategyInterface;
 use Psr\Container\ContainerInterface;
 use Psr\Http\Message\ResponseFactoryInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\StreamFactoryInterface;
+use Psr\Http\Server\RequestHandlerInterface;
 
 return [
     MiddlewareQueueRequestHandler::class => static fn (ContainerInterface $container) => new MiddlewareQueueRequestHandler($container->get(DiTokens::ERROR_HANDLER_404)),
@@ -63,6 +67,12 @@ return [
             public function resolve(RoutableInterface $target): RoutableInterface | false
             {
                 return $target;
+            }
+        },
+        new class () implements RequestHandlerInterface {
+            public function handle(ServerRequestInterface $request): ResponseInterface
+            {
+                return new ResponseStub();
             }
         },
     )

--- a/tests/unit/AppTest.php
+++ b/tests/unit/AppTest.php
@@ -249,6 +249,7 @@ final class AppTest extends TestCase
         $this->expectOutputString("<h1>Not Found</h1>");
         $config = new ContainerConfigurationStub();
         $config[ModelResolverInterface::class] = $this->createStub(ModelResolverInterface::class);
+        $config[DiTokens::UNAUTHORIZED_HANDLER] = $this->createStub(RequestHandlerInterface::class);
         $config[RouteRegistry::class] = new RouteRegistry();
         /**
          * @var Stub&MiddlewareQueueRequestHandler $handlerStub


### PR DESCRIPTION
Framework user should be able to modify the behavior of 'unauthorized' request handling.

Closes #224