### PR TITLE
fix(AbstractProtectedRoutable): use session user object

### DIFF
--- a/src/Auth/AbstractProtectedRoutable.php
+++ b/src/Auth/AbstractProtectedRoutable.php
@@ -26,11 +26,11 @@ abstract class AbstractProtectedRoutable implements RoutableInterface
     {
         $copy = clone $this;
         $copy->user = new User(
-            avatarUrl: $session->avatarUrl ?? "",
-            email: $session->email ?? "",
-            name: $session->name ?? "",
-            nickname: $session->nickname ?? "",
-            picture: $session->picture ?? null,
+            avatarUrl: $session->user->avatarUrl ?? "",
+            email: $session->user->email ?? "",
+            name: $session->user->name ?? "",
+            nickname: $session->user->nickname ?? "",
+            picture: $session->user->picture ?? null,
         );
         return $copy;
     }

--- a/tests/unit/Auth/AuthenticateTest.php
+++ b/tests/unit/Auth/AuthenticateTest.php
@@ -100,7 +100,7 @@ final class AuthenticateTest extends TestCase
     #[TestDox("Shall add user credentials to the target delegate when the request is authenticated")]
     public function testc()
     {
-        $authenticatedUserCredentials = new User(name: "FAKE NAME", nickname: "FAKE NICKNAME", email: "FAKE EMAIL", avatarUrl: "FAKE AVATAR URL");
+        $authenticatedUserCredentials = (object) ["user" => new User(name: "FAKE NAME", nickname: "FAKE NICKNAME", email: "FAKE EMAIL", avatarUrl: "FAKE AVATAR URL")];
         $expectedContent = "<h1>I AM THE TARGET HANDLER</h1>";
         /**
          * @var AuthenticatorInterface&MockObject
@@ -126,6 +126,6 @@ final class AuthenticateTest extends TestCase
          */
         $authenticateAttr = $authenticateAttrs[0]->newInstance();
         $result = $authenticateAttr->getResolvedRoutable(target: $hostClass, authenticator: $authenticatorMock);
-        $this->assertEquals($result->user, $authenticatedUserCredentials);
+        $this->assertEquals($result->user, $authenticatedUserCredentials->user);
     }
 }

--- a/tests/unit/Http/RoutingHandlerTest.php
+++ b/tests/unit/Http/RoutingHandlerTest.php
@@ -430,10 +430,12 @@ final class RoutingHandlerTest extends TestCase
          */
         $authenticatorStub = $this->createStub(AuthenticatorInterface::class);
         $authenticatorStub->method("getCredentials")->willReturn((object) [
-            "name" => $fakeUserName,
-            "nickname" => "FAKE_NICKNAME",
-            "email" => "fake@fake.fake",
-            "avatarUrl" => "https://fake.fake/fake",
+            "user" => (object) [
+                "name" => $fakeUserName,
+                "nickname" => "FAKE_NICKNAME",
+                "email" => "fake@fake.fake",
+                "avatarUrl" => "https://fake.fake/fake",
+            ],
         ]);
         $protectedRoutableResolver = new ProtectedRoutableResolver($authenticatorStub);
         /**


### PR DESCRIPTION
The values are in the `user` property instead of the session object itself.