### PR TITLE
feat(App): add support for queueing middleware

### DIFF
--- a/docs/classes/Phpolar-Phpolar-App.html
+++ b/docs/classes/Phpolar-Phpolar-App.html
@@ -156,6 +156,13 @@
 <dd>Handle and respond to requests from clients.</dd>
 
             <dt class="phpdocumentor-table-of-contents__entry -method -public">
+    <a href="classes/Phpolar-Phpolar-App.html#method_use">use()</a>
+    <span>
+                                &nbsp;: <a href="classes/Phpolar-Phpolar-App.html"><abbr title="\Phpolar\Phpolar\App">App</abbr></a>    </span>
+</dt>
+<dd>Queue the given [PSR-15 middleware](https://www.php-fig.org/psr/psr-15/#22-psrhttpservermiddlewareinterface).</dd>
+
+            <dt class="phpdocumentor-table-of-contents__entry -method -public">
     <a href="classes/Phpolar-Phpolar-App.html#method_useAuthorization">useAuthorization()</a>
     <span>
                                 &nbsp;: <a href="classes/Phpolar-Phpolar-App.html"><abbr title="\Phpolar\Phpolar\App">App</abbr></a>    </span>
@@ -284,6 +291,50 @@
             -public
                                                         "
 >
+    <h4 class="phpdocumentor-element__name" id="method_use">
+        use()
+        <a href="classes/Phpolar-Phpolar-App.html#method_use" class="headerlink"><i class="fas fa-link"></i></a>
+    </h4>
+    <aside class="phpdocumentor-element-found-in">
+    <abbr class="phpdocumentor-element-found-in__file" title="App.php"><a href="files/app.html"><abbr title="App.php">App.php</abbr></a></abbr>
+    :
+    <span class="phpdocumentor-element-found-in__line">77</span>
+
+    </aside>
+
+        <p class="phpdocumentor-summary">Queue the given [PSR-15 middleware](https://www.php-fig.org/psr/psr-15/#22-psrhttpservermiddlewareinterface).</p>
+
+    <code class="phpdocumentor-code phpdocumentor-signature ">
+    <span class="phpdocumentor-signature__visibility">public</span>
+                    <span class="phpdocumentor-signature__name">use</span><span>(</span><span class="phpdocumentor-signature__argument"><span class="phpdocumentor-signature__argument__return-type"><abbr title="\Psr\Http\Server\MiddlewareInterface">MiddlewareInterface</abbr>&nbsp;</span><span class="phpdocumentor-signature__argument__name">$middleware</span></span><span>)</span><span> : </span><span class="phpdocumentor-signature__response_type"><a href="classes/Phpolar-Phpolar-App.html"><abbr title="\Phpolar\Phpolar\App">App</abbr></a></span></code>
+
+    
+        <h5 class="phpdocumentor-argument-list__heading">Parameters</h5>
+    <dl class="phpdocumentor-argument-list">
+                    <dt class="phpdocumentor-argument-list__entry">
+                <span class="phpdocumentor-signature__argument__name">$middleware</span>
+                : <span class="phpdocumentor-signature__argument__return-type"><abbr title="\Psr\Http\Server\MiddlewareInterface">MiddlewareInterface</abbr></span>
+                            </dt>
+            <dd class="phpdocumentor-argument-list__definition">
+                    <section class="phpdocumentor-description"></section>
+
+            </dd>
+            </dl>
+
+    
+
+        <h5 class="phpdocumentor-return-value__heading">Return values</h5>
+    <span class="phpdocumentor-signature__response_type"><a href="classes/Phpolar-Phpolar-App.html"><abbr title="\Phpolar\Phpolar\App">App</abbr></a></span>
+            &mdash;
+        
+    
+</article>
+                    <article
+        class="phpdocumentor-element
+            -method
+            -public
+                                                        "
+>
     <h4 class="phpdocumentor-element__name" id="method_useAuthorization">
         useAuthorization()
         <a href="classes/Phpolar-Phpolar-App.html#method_useAuthorization" class="headerlink"><i class="fas fa-link"></i></a>
@@ -291,7 +342,7 @@
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="App.php"><a href="files/app.html"><abbr title="App.php">App.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">77</span>
+    <span class="phpdocumentor-element-found-in__line">86</span>
 
     </aside>
 
@@ -324,7 +375,7 @@
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="App.php"><a href="files/app.html"><abbr title="App.php">App.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">115</span>
+    <span class="phpdocumentor-element-found-in__line">124</span>
 
     </aside>
 
@@ -371,7 +422,7 @@ will be set up for CSRF detection.</p>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="App.php"><a href="files/app.html"><abbr title="App.php">App.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">92</span>
+    <span class="phpdocumentor-element-found-in__line">101</span>
 
     </aside>
 

--- a/docs/js/searchIndex.js
+++ b/docs/js/searchIndex.js
@@ -16,6 +16,11 @@ Search.appendIndex(
             "summary": "Handle\u0020and\u0020respond\u0020to\u0020requests\u0020from\u0020clients.",
             "url": "classes/Phpolar-Phpolar-App.html#method_receive"
         },                {
+            "fqsen": "\\Phpolar\\Phpolar\\App\u003A\u003Ause\u0028\u0029",
+            "name": "use",
+            "summary": "Queue\u0020the\u0020given\u0020\u005BPSR\u002D15\u0020middleware\u005D\u0028https\u003A\/\/www.php\u002Dfig.org\/psr\/psr\u002D15\/\u002322\u002Dpsrhttpservermiddlewareinterface\u0029.",
+            "url": "classes/Phpolar-Phpolar-App.html#method_use"
+        },                {
             "fqsen": "\\Phpolar\\Phpolar\\App\u003A\u003AuseAuthorization\u0028\u0029",
             "name": "useAuthorization",
             "summary": "Configures\u0020the\u0020application\u0020for\u0020checking\u0020route\u0020authorization.",

--- a/src/App.php
+++ b/src/App.php
@@ -72,6 +72,15 @@ final class App
     }
 
     /**
+     * Queue the given [PSR-15 middleware](https://www.php-fig.org/psr/psr-15/#22-psrhttpservermiddlewareinterface).
+     */
+    public function use(MiddlewareInterface $middleware): App
+    {
+        $this->queueMiddleware($middleware);
+        return $this;
+    }
+
+    /**
      * Configures the application for checking route authorization.
      */
     public function useAuthorization(): App


### PR DESCRIPTION
Users will now be able to add custom or third-party middleware to the processing queue. [PSR-15 middleware](https://www.php-fig.org/psr/psr-15/#22-psrhttpservermiddlewareinterface) is required.