### PR TITLE
ci(auto-merge): ignore php files

### DIFF
--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -2,6 +2,8 @@ name: auto-merge
 
 on:
   pull_request_target:
+    paths-ignore:
+      - '**.php'
 
 jobs:
   auto-merge:


### PR DESCRIPTION
This workflow should only be triggered by dependency updates.