### PR TITLE
ci(phpmd): use paths instead of paths-ignore

### DIFF
--- a/.github/workflows/phpmd.yml
+++ b/.github/workflows/phpmd.yml
@@ -21,11 +21,10 @@ on:
     branches: [ "main" ]
     paths:
       - '**.php'
-    paths-ignore:
-      - 'tests/**'
-      - 'examples/**'
-      - 'config/**'
-      - '.phan/**'
+      - '!tests/**'
+      - '!examples/**'
+      - '!config/**'
+      - '!.phan/**'
 
 permissions:
   contents: read


### PR DESCRIPTION
You may only define one of `paths` and `paths-ignore` for a single event.