### PR TITLE
refactor: use pure-php v2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -55,7 +55,7 @@
         "phpolar/csrf-protection": "^3.0",
         "phpolar/http-message-test-utils": "^0.1.0 || ^0.2.0",
         "phpolar/model": "^1.0",
-        "phpolar/pure-php": "^1.0",
+        "phpolar/pure-php": "^2.0",
         "phpstan/phpstan": "^1.8",
         "phpunit/phpunit": "^10.0",
         "picocss/pico": "2.0.0alpha1",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "32a7988d33659d9fe86ccd5528566b12",
+    "content-hash": "1d4bf0ce0fa12aca21201897afdfc6c4",
     "packages": [
         {
             "name": "guzzlehttp/psr7",
@@ -2393,20 +2393,20 @@
         },
         {
             "name": "phpolar/pure-php",
-            "version": "1.0.4",
+            "version": "2.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpolar/pure-php.git",
-                "reference": "dfe17daaef109c6931d61f65c70b701a4a51479f"
+                "reference": "ea987c10b4f4581079229127a4acb92cf9b77724"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpolar/pure-php/zipball/dfe17daaef109c6931d61f65c70b701a4a51479f",
-                "reference": "dfe17daaef109c6931d61f65c70b701a4a51479f",
+                "url": "https://api.github.com/repos/phpolar/pure-php/zipball/ea987c10b4f4581079229127a4acb92cf9b77724",
+                "reference": "ea987c10b4f4581079229127a4acb92cf9b77724",
                 "shasum": ""
             },
             "require": {
-                "php": "^8.1"
+                "php": ">= 8.1"
             },
             "require-dev": {
                 "ext-mbstring": "*",
@@ -2442,9 +2442,9 @@
             ],
             "support": {
                 "issues": "https://github.com/phpolar/pure-php/issues",
-                "source": "https://github.com/phpolar/pure-php/tree/1.0.4"
+                "source": "https://github.com/phpolar/pure-php/tree/2.0.0"
             },
-            "time": "2023-04-30T17:37:13+00:00"
+            "time": "2023-09-02T01:48:55+00:00"
         },
         {
             "name": "phpolar/response-filter",

--- a/tests/__fakes__/src/config/dependencies/conf.d/fake-custom.php
+++ b/tests/__fakes__/src/config/dependencies/conf.d/fake-custom.php
@@ -16,11 +16,7 @@ use Phpolar\Phpolar\Http\RoutingHandler;
 use Phpolar\Phpolar\Http\RoutingMiddleware;
 use Phpolar\PropertyInjectorContract\PropertyInjectorInterface;
 use Phpolar\Routable\RoutableResolverInterface;
-use Phpolar\PurePhp\Binder;
-use Phpolar\PurePhp\Dispatcher;
-use Phpolar\PurePhp\StreamContentStrategy;
 use Phpolar\PurePhp\TemplateEngine;
-use Phpolar\PurePhp\TemplatingStrategyInterface;
 use Psr\Container\ContainerInterface;
 use Psr\Http\Message\ResponseFactoryInterface;
 use Psr\Http\Message\ServerRequestInterface;
@@ -37,8 +33,7 @@ return [
             }
         }
     ),
-    TemplateEngine::class => static fn (ContainerInterface $container) => new TemplateEngine($container->get(TemplatingStrategyInterface::class), new Binder(), new Dispatcher()),
-    TemplatingStrategyInterface::class => new StreamContentStrategy(),
+    TemplateEngine::class => static fn () => new TemplateEngine(),
     ResponseFactoryInterface::class => new ResponseFactoryStub((new StreamFactoryStub("+w"))->createStream()),
     StreamFactoryInterface::class => new StreamFactoryStub("+w"),
     RouteMap::class => new RouteMap(

--- a/tests/acceptance/AutomaticHtmlEncodingTest.php
+++ b/tests/acceptance/AutomaticHtmlEncodingTest.php
@@ -4,8 +4,6 @@ declare(strict_types=1);
 
 namespace Phpolar\Phpolar;
 
-use Phpolar\PurePhp\Binder;
-use Phpolar\PurePhp\Dispatcher;
 use Phpolar\PurePhp\FileRenderingStrategy;
 use Phpolar\PurePhp\HtmlSafeContext;
 use Phpolar\PurePhp\TemplateEngine;
@@ -16,21 +14,11 @@ use PHPUnit\Framework\TestCase;
 #[TestDox("Automatic HTML Encoding")]
 final class AutomaticHtmlEncodingTest extends TestCase
 {
-    protected function getTemplateEngine()
-    {
-
-        return new TemplateEngine(
-            new FileRenderingStrategy(),
-            new Binder(),
-            new Dispatcher(),
-        );
-    }
-
     #[Test]
     #[TestDox("Shall prevent cross-site scripting injection")]
     public function criterion1()
     {
-        $templatingEngine = $this->getTemplateEngine();
+        $templatingEngine = new TemplateEngine(new FileRenderingStrategy());
         $objWithHacks = new class () {
             public string $hack1 = "<script>alert('hacked');</script>";
             public string $directiveHack1 = "javascript:alert('hacked');";

--- a/tests/acceptance/MemoryUsageTest.php
+++ b/tests/acceptance/MemoryUsageTest.php
@@ -33,8 +33,6 @@ use Phpolar\Phpolar\DependencyInjection\DiTokens;
 use Phpolar\Phpolar\Http\AuthorizationChecker;
 use Phpolar\Phpolar\Http\RequestMethods;
 use Phpolar\PropertyInjectorContract\PropertyInjectorInterface;
-use Phpolar\PurePhp\Binder;
-use Phpolar\PurePhp\Dispatcher;
 use Phpolar\PurePhp\StreamContentStrategy;
 use Phpolar\PurePhp\TemplateEngine;
 use Psr\Container\ContainerInterface;
@@ -92,7 +90,7 @@ final class MemoryUsageTest extends TestCase
         $config[ContainerInterface::class] = static fn (ArrayAccess $conf) => new ConfigurableContainerStub($conf);
         $config[ResponseFactoryInterface::class] = new ResponseFactoryStub();
         $config[StreamFactoryInterface::class] = new StreamFactoryStub("+w");
-        $config[TemplateEngine::class] = new TemplateEngine(new StreamContentStrategy(), new Binder(), new Dispatcher());
+        $config[TemplateEngine::class] = new TemplateEngine();
         $config[TemplatingStrategyInterface::class] = new StreamContentStrategy();
         $config[ContainerInterface::class] = new ConfigurableContainerStub($config);
         $config[DiTokens::CSRF_CHECK_MIDDLEWARE] = static fn (ArrayAccess $config) => new CsrfRequestCheckMiddleware($config[RequestHandlerInterface::class]);

--- a/tests/unit/AppTest.php
+++ b/tests/unit/AppTest.php
@@ -32,9 +32,6 @@ use Phpolar\Phpolar\Http\MiddlewareQueueRequestHandler;
 use Phpolar\Phpolar\Http\RequestMethods;
 use Phpolar\Phpolar\Http\RoutingHandler;
 use Phpolar\PropertyInjectorContract\PropertyInjectorInterface;
-use Phpolar\PurePhp\Binder;
-use Phpolar\PurePhp\Dispatcher;
-use Phpolar\PurePhp\StreamContentStrategy;
 use Phpolar\PurePhp\TemplateEngine;
 use Phpolar\PurePhp\TemplatingStrategyInterface;
 use Phpolar\Routable\RoutableInterface;
@@ -79,11 +76,8 @@ final class AppTest extends TestCase
         CsrfRequestCheckMiddleware|Closure|null $csrfPreRoutingMiddleware = null,
         CsrfResponseFilterMiddleware|Closure|null $csrfPostRoutingMiddleware = null,
     ): ContainerInterface {
-        $config[TemplatingStrategyInterface::class] = new StreamContentStrategy();
-        $config[TemplateEngine::class] = static fn (ArrayAccess $config) => new TemplateEngine($config[TemplatingStrategyInterface::class], $config[Binder::class], $config[Dispatcher::class]);
-        $config[Binder::class] = new Binder();
+        $config[TemplateEngine::class] = static fn () => new TemplateEngine();
         $config[ContainerInterface::class] = new ConfigurableContainerStub($config);
-        $config[Dispatcher::class] = new Dispatcher();
         $config[ResponseFactoryInterface::class] = new ResponseFactoryStub((new StreamFactoryStub("+w"))->createStream());
         $config[StreamFactoryInterface::class] = new StreamFactoryStub("+w");
         $config[MiddlewareQueueRequestHandler::class] = $handler;

--- a/tests/unit/Http/RoutingHandlerTest.php
+++ b/tests/unit/Http/RoutingHandlerTest.php
@@ -65,7 +65,7 @@ final class RoutingHandlerTest extends TestCase
                     return $this->streamFactory ?? new StreamFactoryStub("w");
                 }
                 if ($id === TemplateEngine::class) {
-                    return new TemplateEngine(new StreamContentStrategy(), new Binder(), new Dispatcher());
+                    return new TemplateEngine();
                 }
                 if ($id === DiTokens::UNAUTHORIZED_HANDLER) {
                     return new class () implements RequestHandlerInterface {


### PR DESCRIPTION
The default constructor parameters simplifies creation of the `TemplateEngine` in tests.