### PR TITLE
fix(pure-php): rollback to 2.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -52,7 +52,7 @@
         "phpolar/csrf-protection": "^3.1",
         "phpolar/http-message-test-utils": "^0.1.0 || ^0.2.0",
         "phpolar/model": "^1.2.2",
-        "phpolar/pure-php": "^3.0",
+        "phpolar/pure-php": "^2.0",
         "phpstan/phpstan": "^2.0.3",
         "phpunit/phpunit": "^11.1.3",
         "picocss/pico": "^2.0.6",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "020b1e9bb17acd0b3a5ee399414c461c",
+    "content-hash": "ca3964d0545448760ff9ffc71b19f24f",
     "packages": [
         {
             "name": "guzzlehttp/psr7",
@@ -2455,20 +2455,20 @@
         },
         {
             "name": "phpolar/pure-php",
-            "version": "3.0.0",
+            "version": "2.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpolar/pure-php.git",
-                "reference": "17ed6c6b8d6c010a5e33c2b4fdd7c56311c8db8a"
+                "reference": "e356addc05c8c8a3abcdb3e1783a57e5f9c4f0bc"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpolar/pure-php/zipball/17ed6c6b8d6c010a5e33c2b4fdd7c56311c8db8a",
-                "reference": "17ed6c6b8d6c010a5e33c2b4fdd7c56311c8db8a",
+                "url": "https://api.github.com/repos/phpolar/pure-php/zipball/e356addc05c8c8a3abcdb3e1783a57e5f9c4f0bc",
+                "reference": "e356addc05c8c8a3abcdb3e1783a57e5f9c4f0bc",
                 "shasum": ""
             },
             "require": {
-                "php": "^8.3"
+                "php": ">= 8.1"
             },
             "require-dev": {
                 "ext-mbstring": "*",
@@ -2476,7 +2476,7 @@
                 "php-coveralls/php-coveralls": "^2.5",
                 "phpmd/phpmd": "^2.13",
                 "phpstan/phpstan": "^1.9",
-                "phpunit/phpunit": "^11.1.3",
+                "phpunit/phpunit": "^10.0",
                 "squizlabs/php_codesniffer": "^3.7"
             },
             "type": "library",
@@ -2504,9 +2504,9 @@
             ],
             "support": {
                 "issues": "https://github.com/phpolar/pure-php/issues",
-                "source": "https://github.com/phpolar/pure-php/tree/3.0.0"
+                "source": "https://github.com/phpolar/pure-php/tree/2.0.0"
             },
-            "time": "2024-12-01T20:25:56+00:00"
+            "time": "2023-09-02T23:44:22+00:00"
         },
         {
             "name": "phpstan/phpdoc-parser",


### PR DESCRIPTION
We want to suppport PHP 8.1 and 8.2 but PurePHP 3.0 requires PHP 8.3.