### PR TITLE
feat(ContainerLoader): add alpine linux support

### DIFF
--- a/src/DependencyInjection/ContainerLoader.php
+++ b/src/DependencyInjection/ContainerLoader.php
@@ -22,8 +22,14 @@ final class ContainerLoader
         ContainerInterface $container,
         ArrayAccess $containerConfig,
     ): void {
-        $frameworkDepFiles = glob(Globs::FrameworkDeps->value, GLOB_BRACE);
-        $customDepFiles = glob(Globs::CustomDeps->value, GLOB_BRACE);
+        $frameworkDepFiles = [
+            ...glob(Globs::FrameworkDeps->value),
+            ...glob(Globs::UserFrameworkDeps->value),
+        ];
+        $customDepFiles = [
+            ...glob(Globs::CustomDeps->value),
+            ...glob(Globs::RootCustomDeps->value),
+        ];
 
         if ($frameworkDepFiles === false || $customDepFiles === false) {
             return; // @codeCoverageIgnore

--- a/src/DependencyInjection/Globs.php
+++ b/src/DependencyInjection/Globs.php
@@ -14,10 +14,12 @@ enum Globs: string
      * The frameworks dependencies configuration
      * is located in the source files of the framework.
      */
-    case FrameworkDeps = "{vendor/phpolar/phpolar/,}config/dependencies/framework.php";
+    case FrameworkDeps = "vendor/phpolar/phpolar/config/dependencies/framework.php";
+    case UserFrameworkDeps = "config/dependencies/framework.php";
     /**
      * The custom dependencies directory should be
      * set up in the application using the framework.
      */
-    case CustomDeps = "{src/,}config/dependencies/conf.d/*.php";
+    case CustomDeps = "src/config/dependencies/conf.d/*.php";
+    case RootCustomDeps = "config/dependencies/conf.d/*.php";
 }

--- a/tests/unit/AppTest.php
+++ b/tests/unit/AppTest.php
@@ -188,7 +188,6 @@ final class AppTest extends TestCase
             );
         $config = new ContainerConfigurationStub();
         $routes = new RouteMap($this->getPropertyInjectorStub());
-        $config[RouteMap::class] = $routes;
         $config[RoutingMiddleware::class] = $routingMiddlewareSpy;
         $config[RouteMap::class] = $routes;
         $config[CsrfProtectionRequestHandler::class] = static fn (ArrayAccess $config) =>
@@ -228,6 +227,7 @@ final class AppTest extends TestCase
         $config[DiTokens::UNAUTHORIZED_HANDLER] = $this->createStub(RequestHandlerInterface::class);
         $config[ModelResolverInterface::class] = $this->createStub(ModelResolverInterface::class);
         $config[RouteMap::class] = $givenRoutes;
+        $config[RoutingMiddleware::class] = $this->createStub(RoutingMiddleware::class);
         $container = $this->getContainerFactory($config, $handlerStub);
         App::create(
             $this->configureContainer($container, $config),
@@ -260,6 +260,7 @@ final class AppTest extends TestCase
         $config[ModelResolverInterface::class] = $this->createStub(ModelResolverInterface::class);
         $config[DiTokens::UNAUTHORIZED_HANDLER] = $this->createStub(RequestHandlerInterface::class);
         $config[RouteMap::class] = new RouteMap($this->getPropertyInjectorStub());
+        $config[RoutingMiddleware::class] = $this->createStub(RoutingMiddleware::class);
         /**
          * @var Stub&MiddlewareQueueRequestHandler $handlerStub
          */
@@ -269,7 +270,9 @@ final class AppTest extends TestCase
         $sut = App::create(
             $this->configureContainer($containerFac, $config),
         );
-        $sut->receive(new RequestStub("GET", "/non-existing-route"));
+        $requestStub = new RequestStub("GET", "/non-existing-route");
+        $requestStub->body = null;
+        $sut->receive($requestStub);
         $this->assertSame(ResponseCode::NOT_FOUND, http_response_code());
     }
 
@@ -318,6 +321,7 @@ final class AppTest extends TestCase
         $routes = new RouteMap($this->getPropertyInjectorStub());
         $routes->add(RequestMethods::GET, "/", $this->createStub(AbstractProtectedRoutable::class));
         $config[RouteMap::class] = $routes;
+        $config[RoutingMiddleware::class] = $this->createStub(RoutingMiddleware::class);
         $container = $this->configureContainer($this->getContainerFactory($config, $handler), $config);
         /**
          * @var Stub&MiddlewareInterface

--- a/tests/unit/Http/RoutingHandlerTest.php
+++ b/tests/unit/Http/RoutingHandlerTest.php
@@ -333,7 +333,7 @@ final class RoutingHandlerTest extends TestCase
         $fakeModel = (object) ["name" => $expectedModelName];
         $container = $this->getContainer();
         $registeredRouteHandler = new class () implements RoutableInterface {
-            public function process(#[Model] object $form = null): string
+            public function process(#[Model] ?object $form = null): string
             {
                 return $form->name;
             }
@@ -381,7 +381,7 @@ final class RoutingHandlerTest extends TestCase
         $container = $this->getContainer();
         $registeredRouteHandler = new class () extends AbstractProtectedRoutable {
             #[Authorize]
-            public function process(#[Model] object $form = null): string
+            public function process(#[Model] ?object $form = null): string
             {
                 return $form->name;
             }


### PR DESCRIPTION
The Alpine Linux version of PHP does not support the GLOB_BRACE configuration argument of the glob function.