### PR TITLE
test: exclude response builder from code coverage

### DIFF
--- a/src/Http/ResponseBuilder.php
+++ b/src/Http/ResponseBuilder.php
@@ -7,6 +7,7 @@ use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\StreamFactoryInterface;
 
 /**
+ * @codeCoverageIgnore
  * @deprecated
  */
 final class ResponseBuilder implements ResponseBuilderInterface

--- a/src/Http/ResponseBuilderInterface.php
+++ b/src/Http/ResponseBuilderInterface.php
@@ -7,6 +7,7 @@ use Psr\Http\Message\ResponseInterface;
 /**
  * Builds a PSR-7 Response
  *
+ * @codeCoverageIgnore
  * @deprecated
  */
 interface ResponseBuilderInterface

--- a/tests/unit/Http/RequestProcessingHandlerTest.php
+++ b/tests/unit/Http/RequestProcessingHandlerTest.php
@@ -54,6 +54,7 @@ final class RequestProcessingHandlerTest extends TestCase
             HttpResponseCode::BadRequest,
         ];
         foreach ($responseCodes as $responseCode) {
+
             yield [
                 new ResponseStub($responseCode->value, $responseCode->getLabel()),
                 $responseCode,


### PR DESCRIPTION
ResponseBuilder is deprecated and the unit tests have been deleted.