### PR TITLE
chore(tests): refactor test to use test stubs instead of mocks

### DIFF
--- a/tests/acceptance/ConfigurableFormFieldTest.php
+++ b/tests/acceptance/ConfigurableFormFieldTest.php
@@ -15,12 +15,14 @@ use Phpolar\Model\FormControlTypeDetectionTrait;
 use Phpolar\Model\FormInputTypeDetectionTrait;
 use Phpolar\Model\Hidden;
 use Phpolar\Model\Label;
+use PHPUnit\Framework\Attributes\CoversNothing;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\Attributes\TestDox;
 use PHPUnit\Framework\Attributes\TestWith;
 use PHPUnit\Framework\TestCase;
 
 #[TestDox("Configurable Form Object (Model)")]
+#[CoversNothing]
 final class ConfigurableFormFieldTest extends TestCase
 {
     #[Test]

--- a/tests/unit/Auth/AuthorizeTest.php
+++ b/tests/unit/Auth/AuthorizeTest.php
@@ -28,7 +28,7 @@ final class AuthorizeTest extends TestCase
         $authenticatorMock = $this->createStub(AuthenticatorInterface::class);
         $authenticatorMock->method("isAuthenticated")->willReturn(true);
         $authenticatorMock->method("getUser")->willReturn(["name" => "", "avatarUrl" => "", "nickname" => "", "email" => ""]);
-        $hostClass = new class($expectedContent) extends AbstractRestrictedAccessRequestProcessor
+        $hostClass = new class ($expectedContent) extends AbstractRestrictedAccessRequestProcessor
         {
             public function __construct(public string $content) {}
 
@@ -59,7 +59,7 @@ final class AuthorizeTest extends TestCase
         $targetDelegateStub->method("process")->willReturn("<h1>I AM THE TARGET HANDLER</h1>");
         $authenticatorMock = $this->createStub(AuthenticatorInterface::class);
         $authenticatorMock->method("isAuthenticated")->willReturn(false);
-        $hostClass = new class($expectedContent) implements RequestProcessorInterface
+        $hostClass = new class ($expectedContent) implements RequestProcessorInterface
         {
             public function __construct(public string $content) {}
 
@@ -90,7 +90,7 @@ final class AuthorizeTest extends TestCase
         $authenticatorMock = $this->createStub(AuthenticatorInterface::class);
         $authenticatorMock->method("isAuthenticated")->willReturn(true);
         $authenticatorMock->method("getUser")->willReturn($authenticatedUser);
-        $hostClass = new class($expectedContent) extends AbstractRestrictedAccessRequestProcessor
+        $hostClass = new class ($expectedContent) extends AbstractRestrictedAccessRequestProcessor
         {
             public function __construct(public string $content) {}
 

--- a/tests/unit/Auth/AuthorizeTest.php
+++ b/tests/unit/Auth/AuthorizeTest.php
@@ -4,18 +4,13 @@ declare(strict_types=1);
 
 namespace Phpolar\Phpolar\Auth;
 
-use Generator;
-use Phpolar\Phpolar\Tests\Stubs\ConfigurableContainerStub;
-use Phpolar\Phpolar\Tests\Stubs\ContainerConfigurationStub;
 use PhpContrib\Authenticator\AuthenticatorInterface;
 use Phpolar\HttpRequestProcessor\RequestProcessorInterface;
 use PHPUnit\Framework\Attributes\CoversClass;
-use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\TestDox;
 use PHPUnit\Framework\Attributes\UsesClass;
-use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\MockObject\Stub;
 use PHPUnit\Framework\TestCase;
-use Psr\Container\ContainerInterface;
 use ReflectionMethod;
 
 #[CoversClass(Authorize::class)]
@@ -23,23 +18,17 @@ use ReflectionMethod;
 #[UsesClass(AbstractRestrictedAccessRequestProcessor::class)]
 final class AuthorizeTest extends TestCase
 {
-    public static function getContainerStub(): Generator
-    {
-        yield [new ConfigurableContainerStub(new ContainerConfigurationStub())];
-    }
-
     #[TestDox("Shall return the target delegate when the request is authenticated")]
-    #[DataProvider("getContainerStub")]
-    public function testa(ContainerInterface $container)
+    public function testa()
     {
         $expectedContent = "<h1>I AM THE TARGET HANDLER</h1>";
         /**
-         * @var AuthenticatorInterface&MockObject
+         * @var AuthenticatorInterface&Stub
          */
-        $authenticatorMock = $this->createMock(AuthenticatorInterface::class);
+        $authenticatorMock = $this->createStub(AuthenticatorInterface::class);
         $authenticatorMock->method("isAuthenticated")->willReturn(true);
         $authenticatorMock->method("getUser")->willReturn(["name" => "", "avatarUrl" => "", "nickname" => "", "email" => ""]);
-        $hostClass = new class ($expectedContent) extends AbstractRestrictedAccessRequestProcessor
+        $hostClass = new class($expectedContent) extends AbstractRestrictedAccessRequestProcessor
         {
             public function __construct(public string $content) {}
 
@@ -59,7 +48,7 @@ final class AuthorizeTest extends TestCase
          * @var RequestProcessorInterface
          */
         $result = $authenticateAttr->getResolvedRoutable(target: $hostClass, authenticator: $authenticatorMock);
-        $this->assertEquals($hostClass->process($container), $result->process($container));
+        $this->assertEquals($hostClass->process(), $result->process());
     }
 
     #[TestDox("Shall return false when the request is not authenticated")]
@@ -68,9 +57,9 @@ final class AuthorizeTest extends TestCase
         $expectedContent = "<h1>I AM THE FALLBACK HANDLER</h1>";
         $targetDelegateStub = $this->createStub(AbstractRestrictedAccessRequestProcessor::class);
         $targetDelegateStub->method("process")->willReturn("<h1>I AM THE TARGET HANDLER</h1>");
-        $authenticatorMock = $this->createMock(AuthenticatorInterface::class);
+        $authenticatorMock = $this->createStub(AuthenticatorInterface::class);
         $authenticatorMock->method("isAuthenticated")->willReturn(false);
-        $hostClass = new class ($expectedContent) implements RequestProcessorInterface
+        $hostClass = new class($expectedContent) implements RequestProcessorInterface
         {
             public function __construct(public string $content) {}
 
@@ -96,12 +85,12 @@ final class AuthorizeTest extends TestCase
         $authenticatedUser = ["name" => "FAKE NAME", "nickname" => "FAKE NICKNAME", "email" => "FAKE EMAIL", "avatarUrl" => "FAKE AVATAR URL"];
         $expectedContent = "<h1>I AM THE TARGET HANDLER</h1>";
         /**
-         * @var AuthenticatorInterface&MockObject
+         * @var AuthenticatorInterface&Stub
          */
-        $authenticatorMock = $this->createMock(AuthenticatorInterface::class);
+        $authenticatorMock = $this->createStub(AuthenticatorInterface::class);
         $authenticatorMock->method("isAuthenticated")->willReturn(true);
         $authenticatorMock->method("getUser")->willReturn($authenticatedUser);
-        $hostClass = new class ($expectedContent) extends AbstractRestrictedAccessRequestProcessor
+        $hostClass = new class($expectedContent) extends AbstractRestrictedAccessRequestProcessor
         {
             public function __construct(public string $content) {}
 

--- a/tests/unit/Http/RequestAuthorizerTest.php
+++ b/tests/unit/Http/RequestAuthorizerTest.php
@@ -25,9 +25,9 @@ final class RequestAuthorizerTest extends TestCase
     {
         $givenRoutable = $this->createStub(RequestProcessorInterface::class);
         $decoratedRoutable = $this->createStub(AbstractRestrictedAccessRequestProcessor::class)->withUser((object)["id" => 123]);
-        $routableResolverMock = $this->createMock(RequestProcessorResolverInterface::class);
+        $routableResolverMock = $this->createStub(RequestProcessorResolverInterface::class);
         $routableResolverMock->method("resolve")->willReturn($decoratedRoutable);
-        $unauthHander = $this->createMock(RequestHandlerInterface::class);
+        $unauthHander = $this->createStub(RequestHandlerInterface::class);
         $unauthHander->method("handle")->willReturn(new ResponseStub(ResponseCode::Unauthorized->value));
         $sut = new RequestAuthorizer($routableResolverMock, $unauthHander);
         $result = $sut->authorize($givenRoutable, new RequestStub());
@@ -38,9 +38,9 @@ final class RequestAuthorizerTest extends TestCase
     public function testb()
     {
         $givenRoutable = $this->createStub(RequestProcessorInterface::class);
-        $routableResolverMock = $this->createMock(RequestProcessorResolverInterface::class);
+        $routableResolverMock = $this->createStub(RequestProcessorResolverInterface::class);
         $routableResolverMock->method("resolve")->willReturn(false);
-        $unauthHander = $this->createMock(RequestHandlerInterface::class);
+        $unauthHander = $this->createStub(RequestHandlerInterface::class);
         $unauthHander->method("handle")->willReturn(new ResponseStub(ResponseCode::Unauthorized->value));
         $sut = new RequestAuthorizer($routableResolverMock, $unauthHander);
         $result = $sut->authorize($givenRoutable, new RequestStub());


### PR DESCRIPTION
PHPUnit began displaying notices when mocks were used without an expectation.