### PR TITLE
refactor(auth): accept single ReflectionAttribute in resolveRoutable()

### DIFF
--- a/src/Auth/RestrictedAccessRequestProcessorResolver.php
+++ b/src/Auth/RestrictedAccessRequestProcessorResolver.php
@@ -38,7 +38,7 @@ final readonly class RestrictedAccessRequestProcessorResolver implements Request
         }
 
         return $this->resolveRoutable(
-            authenticateAttrs: $authenticateAttrs,
+            authenticateAttr: $authenticateAttrs[0],
             target: $target,
         );
     }
@@ -53,17 +53,17 @@ final readonly class RestrictedAccessRequestProcessorResolver implements Request
     }
 
     /**
-     * @param ReflectionAttribute<Authorize>[] $authenticateAttrs
+     * @param ReflectionAttribute<Authorize> $authenticateAttr
      */
     private function resolveRoutable(
-        array $authenticateAttrs,
+        ReflectionAttribute $authenticateAttr,
         AbstractRestrictedAccessRequestProcessor $target,
     ): RequestProcessorInterface | false {
         /**
          * @var Authorize
          */
-        $authenticateAttr = $authenticateAttrs[0]->newInstance();
-        return $authenticateAttr->getResolvedRoutable(
+        $authorizeInstance = $authenticateAttr->newInstance();
+        return $authorizeInstance->getResolvedRoutable(
             target: $target,
             authenticator: $this->authenticator,
         );

--- a/tests/unit/Auth/RestrictedAccessRequestProcessorResolverTest.php
+++ b/tests/unit/Auth/RestrictedAccessRequestProcessorResolverTest.php
@@ -22,7 +22,7 @@ use PHPUnit\Framework\TestCase;
 #[UsesClass(User::class)]
 final class RestrictedAccessRequestProcessorResolverTest extends TestCase
 {
-    #[TestDox("Shall return the false when the authenticator returns null")]
+    #[TestDox("Shall return false when a single Authorize attribute is present and the authenticator returns null")]
     public function testa()
     {
         /**
@@ -43,7 +43,7 @@ final class RestrictedAccessRequestProcessorResolverTest extends TestCase
         $this->assertFalse($result);
     }
 
-    #[TestDox("Shall return the target routable when the authenticator returns an object")]
+    #[TestDox("Shall return the target routable when a single Authorize attribute resolves an authenticated user")]
     public function testb()
     {
         /**


### PR DESCRIPTION
Change resolveRoutable() signature to accept a single ReflectionAttribute<Authorize> instead of an array, since only the first element was ever used. Update resolve() to pass $authenticateAttrs[0] directly and adjust docblocks/type hints accordingly. Clarify TestDox descriptions in
RestrictedAccessRequestProcessorResolverTest to reflect the single-attribute resolution path.

Fixes #564